### PR TITLE
change Grooming to Refinement

### DIFF
--- a/docs/04-how-we-work/agile-practices/backlog-grooming.md
+++ b/docs/04-how-we-work/agile-practices/backlog-grooming.md
@@ -1,28 +1,28 @@
-# Backlog Grooming (Refinement)
+# Backlog Refinement
 
 ## What it is:
 
-Backlog Grooming, or Backlog Refinement, is the process of reviewing, updating, adding, deleting and prioritizing stories in the product backlog in order to prepare for the next [Sprint Planning Meeting](sprint-planning-meetings.md). The product backlog is simply the list of all the tasks that need to be completed within a project.
+Backlog Refinement (previously Backlog Grooming) is the process of reviewing, updating, adding, deleting and prioritizing stories in the product backlog in order to prepare for the next [Sprint Planning Meeting](sprint-planning-meetings.md). The product backlog is simply the list of all the tasks that need to be completed within a project.
 
 ## Who should participate:
 
-The Backlog Grooming meeting should be attended by members of the project team, the Scrum Master, and the Product Owner. Other stakeholders may attend and participate in this meeting as needed, but their numbers should be limited.
+The Backlog Refinement meeting should be attended by members of the project team, the Scrum Master, and the Product Owner. Other stakeholders may attend and participate in this meeting as needed, but their numbers should be limited.
 
 ## How to do it:
 
-Backlog grooming is a versatile and flexible meeting that can be formatted in a number of ways depending on the needs of the project. The overall objective of this time is to have the team arrive at a shared understanding of items in the product backlog by adding clarity and priority ratings to the epics, stories, and tasks in the backlog. This ensures that sprint planning will be a well-informed and efficient activity.
+Backlog Refinement is a versatile and flexible meeting that can be formatted in a number of ways depending on the needs of the project. The overall objective of this time is to have the team arrive at a shared understanding of items in the product backlog by adding clarity and priority ratings to the epics, stories, and tasks in the backlog. This ensures that sprint planning will be a well-informed and efficient activity.
 
 Aided by the Scrum Master, it is the Product Owner's job to lead this meeting and represent his/her needs by defining which stories are high priority and by providing details to the team on specific stories.
 
 During this meeting, time may also be spent breaking down large stories or epics into smaller stories or tasks that can be accomplished during a single sprint. This is also a time when specific acceptance criteria could be added to stories or tasks so that the definition of "done" is known for those items. Technical approaches, diagrams, and assets can be added to the backlog items. Team members can ask questions of the Product Owner to clarify items.
 
-This meeting should be time boxed. It is acceptable if the team is not able to refine the entire backlog during the meeting, as long as the most important items as defined by the Product Owner have been refined. The goal of the refinement/grooming session should be to prepare an appropriate amount of items in the product backlog for the team to discuss during the [Sprint Planning Meeting](sprint-planning-meetings.md) and to prepare at least enough tasks to keep the project team busy for the duration of the sprint.
+This meeting should be time boxed. It is acceptable if the team is not able to refine the entire backlog during the meeting, as long as the most important items as defined by the Product Owner have been refined. The goal of the Refinement session should be to prepare an appropriate amount of items in the product backlog for the team to discuss during the [Sprint Planning Meeting](sprint-planning-meetings.md) and to prepare at least enough tasks to keep the project team busy for the duration of the sprint.
 
-Backlog grooming is a continuous process at CivicActions. It is expected that most projects will spend 30 to 60 minutes per week performing backlog grooming. This helps the product owner maintain a mindset of prioritization, and the team to always have an up-to-date understanding of what work will deliver the most value to the client.
+Backlog Refinement is a continuous process at CivicActions. It is expected that most projects will spend 30 to 60 minutes per week performing Backlog Refinement. This helps the product Owner maintain a mindset of prioritization, and the team to always have an up-to-date understanding of what work will deliver the most value to the client.
 
 ## Why to do it:
 
-Backlog Grooming sessions are an important part of preparation for [Sprint Planning Meetings](sprint-planning-meetings.md). Without regular backlog grooming, sprint planning can become a painfully long exercise where details and priorities must be discussed before decisions about the sprint can be made.
+Backlog Refinement sessions are an important part of preparation for [Sprint Planning Meetings](sprint-planning-meetings.md). Without regular Backlog Refinement, sprint planning can become a painfully long exercise where details and priorities must be discussed before decisions about the sprint can be made.
 
 ## Additional Resources:
 


### PR DESCRIPTION
We are supposed to stop using the word Grooming as it has other meanings

[//]: # (rtdbot-start)

URL of RTD document: https://civicactions-handbook.readthedocs.io/en/akaroleff-patch-4/ ![Documentation Status](https://readthedocs.org/projects/civicactions-handbook/badge/?version=akaroleff-patch-4)

[//]: # (rtdbot-end)
