### PR TITLE
Updating PII training link on security-training.md

### DIFF
--- a/company-policies/new-hire-orientation/security-training.md
+++ b/company-policies/new-hire-orientation/security-training.md
@@ -38,7 +38,7 @@ Engineers and Project Managers and anyone directly involved in client site opera
 
 CivicActions Employees and Contractors regularly refresh their understanding of privacy regulations and security controls with the latest available information, including:
 
-- Course: [Identifying and Safeguarding Personally Identifiable Information (PII)](https://securityawareness.usalearning.gov/piiv2/index.htm)
+- Course: [Identifying and Safeguarding Personally Identifiable Information (PII)](https://securityawareness.dcsa.mil/piiv2/content/index.html)
 - Review: [CivicActions Employee/Contractor SecurityPolicy](../security.md)
 - Internal: Yearly trainings/quizzes scheduled by the CivicActions Security Team
 


### PR DESCRIPTION
## Describe your changes

The previous link now goes to a 404 page so replacing link with https://securityawareness.dcsa.mil/piiv2/content/index.html

## Review Steps

- [ ] Visit page https://civicactions-handbook--1634.org.readthedocs.build/en/1634/company-policies/new-hire-orientation/security-training/#privacy-and-security-trainings and try the link with text 'Identifying and Safeguarding Personally Identifiable Information (PII)'

## Checklist before requesting review

- [x] Reviewed [documentation](https://guidebook.civicactions.com/en/latest/about-this-guidebook/editing-the-guidebook/#step-4-make-your-pull-request-pr)
- [x] Confirmed all checks for this pull request are passing


<!-- readthedocs-preview civicactions-handbook start -->
----
📚 Documentation preview 📚: https://civicactions-handbook--1634.org.readthedocs.build/en/1634/

<!-- readthedocs-preview civicactions-handbook end -->