### PR TITLE
Ignoring gnu.org from linkchecker since it is unreliable

### DIFF
--- a/.config/linkspector.yml
+++ b/.config/linkspector.yml
@@ -11,3 +11,4 @@ ignorePatterns:
   # NOTE: Unreliable sites below
   - pattern: "^https://linux.die.net/.*"
   - pattern: "^https://www.congress.gov/.*"
+  - pattern: "^https://www.gnu.org/.*"


### PR DESCRIPTION
## Describe your changes

Failed a couple of times in the weekly checker https://github.com/CivicActions/guidebook/actions/runs/18091618894/job/51473361885

## Review Steps

- [x] Confirm link checks are passing

## Checklist before requesting review

- [x] Reviewed [documentation](https://guidebook.civicactions.com/en/latest/about-this-guidebook/editing-the-guidebook/#step-4-make-your-pull-request-pr)
- [x] Confirmed all checks for this pull request are passing


<!-- readthedocs-preview civicactions-handbook start -->
----
📚 Documentation preview 📚: https://civicactions-handbook--1647.org.readthedocs.build/en/1647/

<!-- readthedocs-preview civicactions-handbook end -->