### PR TITLE
Update OS version from Ubuntu 20.04 to 24.04 for read the docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.10"
   jobs:


### PR DESCRIPTION
## Describe your changes

Recommended by RTD since 20.04 is deprecated see https://docs.readthedocs.com/platform/stable/config-file/v2.html#build-os and https://ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-heres-how-to-prepare

## Review Steps

- [ ] Confirm the read the docs preview site builds successfully.

## Checklist before requesting review

- [x] Reviewed [documentation](https://guidebook.civicactions.com/en/latest/about-this-guidebook/editing-the-guidebook/#step-4-make-your-pull-request-pr)
- [x] Confirmed all checks for this pull request are passing


<!-- readthedocs-preview civicactions-handbook start -->
----
📚 Documentation preview 📚: https://civicactions-handbook--1729.org.readthedocs.build/en/1729/

<!-- readthedocs-preview civicactions-handbook end -->