### PR TITLE
update Incident Response and Contingency Plans

### DIFF
--- a/common-practices-tools/security/contingency-plan.md
+++ b/common-practices-tools/security/contingency-plan.md
@@ -38,16 +38,13 @@ notifies the people authorized to make system-level recovery decisions:
 ### Recovery
 
 The SIRT works to restore the system following the [assessment](incident-response-plan.md#4-assess-the-incident)
-and [remediation](incident-response-plan.md#5-remediate) processes in the IRP. In addition,
-the SIRT should:
+and [remediation](incident-response-plan.md#5-remediate) processes in the IRP. In addition, the SIRT should:
 
 - Identify the root cause and scope of the disruption before restoring service.
 - Restore from the most recent known-good backup or snapshot if data integrity is in doubt.
-    Confirm the restoration target's integrity before promotion to production.
-- If an external dependency is involved, consult the [external dependencies](#some-external-dependencies)
-    section for fallback options and monitor the dependency's status page for recovery.
-- Document all recovery actions taken, including timestamps, in the designated
-    [communication channel](incident-response-plan.md#communication-channels).
+- Confirm the restoration target's integrity before promotion to production.
+- If an external dependency is involved, consult the [external dependencies](#external-dependencies) section for fallback options and monitor the dependency's status page for recovery.
+- Document all recovery actions taken, including timestamps, in the designated [communication channel](incident-response-plan.md#communication-channels).
 - Obtain Authorizing Official approval before re-deploying to a new region or environment.
 
 ### Reconstitution
@@ -66,7 +63,7 @@ Once verification passes, the Incident Commander:
 1. Notifies the Product Owner, CivicActions managers, and affected users that service is restored.
 1. Schedules a retrospective following the [security incident retrospective process](incident-response-plan.md#conducting-a-retrospective)..
 
-## Some external dependencies
+## External dependencies
 
 CivicActions managed systems often depend on several external services. In the event one or more of these services has a long-term disruption, the SIRT will mitigate impact by following this plan. Zero or more of the following services may be involved:
 

--- a/common-practices-tools/security/contingency-plan.md
+++ b/common-practices-tools/security/contingency-plan.md
@@ -43,11 +43,11 @@ the SIRT should:
 
 - Identify the root cause and scope of the disruption before restoring service.
 - Restore from the most recent known-good backup or snapshot if data integrity is in doubt.
-  Confirm the restoration target's integrity before promotion to production.
+    Confirm the restoration target's integrity before promotion to production.
 - If an external dependency is involved, consult the [external dependencies](#some-external-dependencies)
-  section for fallback options and monitor the dependency's status page for recovery.
+    section for fallback options and monitor the dependency's status page for recovery.
 - Document all recovery actions taken, including timestamps, in the designated
-  [communication channel](incident-response-plan.md#communication-channels).
+    [communication channel](incident-response-plan.md#communication-channels).
 - Obtain Authorizing Official approval before re-deploying to a new region or environment.
 
 ### Reconstitution
@@ -63,8 +63,8 @@ Before declaring the system operational, the SIRT should verify:
 Once verification passes, the Incident Commander:
 
 1. Declares recovery complete and lifts any access restrictions imposed during containment.
-2. Notifies the Product Owner, CivicActions managers, and affected users that service is restored.
-3. Schedules a retrospective following the [security incident retrospective process](incident-response-plan.md#conducting-a-retrospective)..
+1. Notifies the Product Owner, CivicActions managers, and affected users that service is restored.
+1. Schedules a retrospective following the [security incident retrospective process](incident-response-plan.md#conducting-a-retrospective)..
 
 ## Some external dependencies
 

--- a/common-practices-tools/security/contingency-plan.md
+++ b/common-practices-tools/security/contingency-plan.md
@@ -4,41 +4,13 @@ title: Contingency plan
 
 # CivicActions Common Contingency Plan
 
-## Table of Contents
-
-<!--ts-->
-
-- [Applicability](#applicability)
-- [Overview](#overview)
-- [Recovery objective](#recovery-objective)
-- [Incident Response Team information](#incident-response-team-information)
-    - [Contact information](#contact-information)
-- [Contingency plan outline](#contingency-plan-outline)
-    - [Activation and notification](#activation-and-notification)
-    - [Recovery](#recovery)
-    - [Reconstitution](#reconstitution)
-- [External dependencies](#external-dependencies)
-    - [GitHub](#github)
-    - [GitLab](#gitlab)
-    - [StatusCake](#statuscake)
-    - [OpsGenie](#opsgenie)
-    - [JIRA](#jira)
-    - [Slack](#slack)
-    - [AWS](#aws)
-    - [Acquia Cloud Enterprise (ACE) Platform as a Service (PaaS)](#acquia-cloud-enterprise-ace-platform-as-a-service-paas)
-- [How this document works](#how-this-document-works)
-
-<!-- Added by: fen, at: Fri Jan 22 10:51:18 PM EST 2021 -->
-
-<!--te-->
-
 ## Applicability
 
 **Note:** This Contingency Plan applies only to systems for which CivicActions has negotiated and defined Incident Response/Contingency Plan (IRCP) operations. Each IRCP-managed system will have a specific, tailored version of this Contingency Plan or in some cases a completely unique Contingency Plan will be developed. All CivicActions employees are aware of the procedures outlined herein.
 
 ## Overview
 
-This Contingency Plan provides baseline guidance for the CivicActions Team when managing the disruption, compromise, or failure of any component of a CivicActions IRCP managed system, product or service ("system"). As a general guideline, we consider "disruption" to mean unexpected downtime or significantly reduced service lasting longer than:
+This Contingency Plan provides baseline guidance for the CivicActions Security Incident Response Team (SIRT) when managing the disruption, compromise, or failure of any component of a CivicActions IRCP managed system, product or service ("system"). As a general guideline, we consider "disruption" to mean unexpected downtime or significantly reduced service lasting longer than:
 
 - 30 minutes 0900 - 2100 Eastern Time Monday through Friday (standard U.S. business hours)
 - 90 minutes at other times
@@ -49,61 +21,59 @@ Some clients will create and maintain a Contingency Plan defining procedures spe
 
 ## Recovery objective
 
-Short-term disruptions lasting less than 30 minutes are outside the scope of this plan.
-
 More than 3 hours of any system being offline during standard U.S. business hours (0900 - 2100 Eastern Time) is considered unacceptable. Our objective is to recover from any significant problem (disruption, compromise, or failure) within that span of time.
-
-## Incident Response Team information
-
-### Contact information
-
-Team contact information is available in the Google Drive:
-
-- [CivicActions Incident Response Team contact sheet](https://drive.google.com/open?id=1P9TePYm2Gkly8EjxCzA2EmlTjUIBypE7-CbCZrRN1EA) with names and roles for CivicActions' Incident Response Team members. All CivicActions employees have access to this sheet.
 
 ## Contingency plan outline
 
 ### Activation and notification
 
-The first Incident Response Team member who notices or reports a potential contingency-plan-level problem becomes the **Incident Commander** (IC) until recovery efforts are complete or the Incident Commander role is explicitly reassigned.
+The [Incident Response Plan](incident-response-plan.md) is activated first when a disruption
+is reported. During the Assessment phase, if HIGH severity or a projected need for Disaster
+Recovery is identified, the Incident Commander (IC) activates this Contingency Plan and
+notifies the people authorized to make system-level recovery decisions:
 
-If the problem is identified as part of a [security incident response situation](incident-response-plan.md) (or becomes a security incident response situation), the same Incident Commander (IC) should handle the overall situation, since these response processes must be coordinated.
-
-The IC first notifies and coordinates with the people who are authorized to decide that the system is in a contingency plan situation:
-
-- From CivicActions:
-    - Incident Commander
-    - Project Manager
-    - CivicActions Incident Response Team
-- From the customer:
-    - Product Owner
-    - Users, when applicable
-
-The IC keeps a log of the situation in the [`#general`](https://civicactions.slack.com/messages/general/) Slack channel or within a client-specific Slack channel, JIRA ticket, or GitHub issue. If this is also a security incident, the IC also follows the [security incident communications process](incident-response-plan.md#3-initiate-the-response). The IC should delegate assistant ICs for aspects of the situation as necessary.
+- From CivicActions: Project Manager, SIRT members assigned to the incident
+- From the customer: Product Owner, and users if service is degraded
 
 ### Recovery
 
-The Incident Response Team assesses the situation and works to recover the system. See the list of [external dependencies](#external-dependencies) for procedures for recovery from problems with external services.
+The SIRT works to restore the system following the [assessment](incident-response-plan.md#4-assess-the-incident)
+and [remediation](incident-response-plan.md#5-remediate) processes in the IRP. In addition,
+the SIRT should:
 
-If this is also a security incident, the IC also follows the [security incident assessment](incident-response-plan.md#4-assess-the-incident) and [remediation](incident-response-plan.md#5-remediate) processes.
-
-If the IC assesses that the overall response process is likely to last longer than 3 hours, the IC should organize shifts so that each responder works on response for no longer than 3 hours at a time, including handing off their own responsibility to a new IC after 3 hours.
+- Identify the root cause and scope of the disruption before restoring service.
+- Restore from the most recent known-good backup or snapshot if data integrity is in doubt.
+  Confirm the restoration target's integrity before promotion to production.
+- If an external dependency is involved, consult the [external dependencies](#some-external-dependencies)
+  section for fallback options and monitor the dependency's status page for recovery.
+- Document all recovery actions taken, including timestamps, in the designated
+  [communication channel](incident-response-plan.md#communication-channels).
+- Obtain Authorizing Official approval before re-deploying to a new region or environment.
 
 ### Reconstitution
 
-The Incident Response Team tests and validates the system as operational.
+Before declaring the system operational, the SIRT should verify:
 
-The Incident Commander declares that recovery efforts are complete and notifies all relevant people. The last step is to schedule a postmortem to discuss the event. This is the same as the [security incident retrospective process](incident-response-plan.md#conducting-a-retrospective).
+- [ ] Core application functions respond as expected (smoke test or runbook verification).
+- [ ] Data integrity is confirmed — no missing, corrupted, or inconsistent records.
+- [ ] Authentication and access controls are functioning correctly.
+- [ ] Monitoring and alerting are active and reporting normally.
+- [ ] No indicators of compromise remain.
 
-## External dependencies
+Once verification passes, the Incident Commander:
 
-CivicActions managed systems often depend on several external services. In the event one or more of these services has a long-term disruption, the team will mitigate impact by following this plan. Zero or more of the following services may be involved:
+1. Declares recovery complete and lifts any access restrictions imposed during containment.
+2. Notifies the Product Owner, CivicActions managers, and affected users that service is restored.
+3. Schedules a retrospective following the [security incident retrospective process](incident-response-plan.md#conducting-a-retrospective)..
+
+## Some external dependencies
+
+CivicActions managed systems often depend on several external services. In the event one or more of these services has a long-term disruption, the SIRT will mitigate impact by following this plan. Zero or more of the following services may be involved:
 
 ### GitHub
 
 - **Service:** <https://github.com>
-- **Status:** <https://status.github.com/>
-- **Status:** <https://twitter.com/githubstatus>
+- **Status:** <https://www.githubstatus.com/>
 
 If GitHub becomes unavailable, systems will continue to operate in its current state. The
 disruption would only impact the team's ability to update code on the instances.
@@ -111,74 +81,52 @@ disruption would only impact the team's ability to update code on the instances.
 ### GitLab
 
 - **Service:** <https://git.civicactions.net/>
-- **Status:** <https://app.statuscake.com/AllStatus.php?tid=1702974>
+- **Status:** <https://app.statuscake.com/UptimeStatus.php?tid=1702974>
 
 If GitLab becomes unavailable, systems will continue to operate in their current state. The disruption would impact the team's ability to update code on the instances, which could have significant impact.
 
 ### StatusCake
 
 - **Service:** <https://status.statuscake.com/>
-- **Status:** <https://twitter.com/StatusCakeTeam>
 
-If there is a disruption in the StatusCake service, the Incident Response team will be notified by email.
+If there is a disruption in the StatusCake service, the SIRT will be notified by email.
 
 ### OpsGenie
 
 - **Service:** <https://app.opsgenie.com/alert/>
 - **Status:** <https://status.opsgenie.com/>
-- **Status:** <https://twitter.com/opsgenie>
 
-If there is a disruption in the OpsGenie service, all alerts automatically get delivered to the team via email.
-
-### JIRA
-
-- **Service:** <https://PROJECT.atlassian.net/>
-- **Status:** <https://twitter.com/JIRA>
-
-There is no direct impact to the platform if a disruption occurs. Primary incident communications will move to the [CivicActions `#general`](https://civicactions.slack.com/) Slack channel.
+If there is a disruption in the OpsGenie service, all alerts automatically get delivered to the SIRT via email.
 
 ### Slack
 
 - **Service:** <https://civicactions.slack.com/>
 - **Status:** <https://status.slack.com/>
-- **Status:** <https://twitter.com/SlackStatus>
+
+There is no direct impact to the platform if a disruption occurs, thugh 90% of CivicActons communications are via Slack.
+Primary incident communications will move to Zoom or Google Meet.
+
+### Zoom
+
+- **Service:** <https://civicactions.zoom.us/>
+- **Status:** <https://www.zoomstatus.com/>
 
 There is no direct impact to the platform if a disruption occurs.
-Primary incident communications will move to one of:
 
-- IT Zoom: <https://zoom.us/>
-- Google Meet: <https://meet.google.com/>
-- Google Chat: <https://chat.google.com/>
+### Google Workspace
+
+- **Service:** <https://admin.google.com/?dn=civicactions.com>
+- **Status:** <https://www.google.com/appsstatus/dashboard/>
+
+CivicActions depends upon Google Workspace.
 
 ### AWS
 
 - **Service:** <https://signin.aws.amazon.com/console>
+- **Portal:** <https://civicactions.awsapps.com/start/#/?tab=accounts>
 - **Status:** <https://health.aws.amazon.com/health/status>
 
-If needed, you can [manage and create new servers](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1).
-
-In case of a **significant** disruption, after receiving approval from our Authorizing Official, the CivicActions team will deploy a new instance of the entire system to a [different region](https://us-west-1.console.aws.amazon.com/ec2/v2/home?region=us-west-1).
-
-### Acquia Cloud Enterprise (ACE) Platform as a Service (PaaS)
-
-- **Service:** <https://docs.acquia.com/en/stable/support/status/>
-- **Status:** <https://status.acquia.com/>
-
-Some sites are hosted on the Acquia Cloud Enterprise (ACE) PaaS
-<https://cloud.acquia.com/app/develop> which is layered on top of the Amazon Web Services
-(AWS) FedRAMP-certified cloud in the us-east region. See [ACE
-Status](https://status.acquia.com/) and [AWS status](https://health.aws.amazon.com/health/status).
-
-- **Acquia Security:** <https://docs.acquia.com/acquia-cloud/arch/security>
-- **Acquia Monitoring:** <https://docs.acquia.com/acquia-cloud/arch/security/monitor>
-- **Acquia Availability & Backups:** <https://docs.acquia.com/acquia-cloud/arch/security/availability>
-
-Acquia Cloud takes hourly snapshots of EBS volumes that are saved to Amazon S3 providing
-geographically distributed data centers.
-
-In case of a significant disruption, after receiving approval from our Authorizing
-Official, the CivicActions and Acquia teams will deploy a new instance of the entire
-system to a different region.
+In case of a **significant** disruption, after receiving required client approval, the CivicActions SIRT will deploy a new instance of the entire system to a [different region](https://us-west-1.console.aws.amazon.com/ec2/v2/home?region=us-west-1).
 
 ## How this document works
 
@@ -188,4 +136,4 @@ This plan is most effective if all CivicActions team members know about it, reme
     - All changes to the plan should be communicated to the rest of the team.
     - At least once a year, and after major changes to our systems, we review and update the plan.
 - How we protect this plan from unauthorized modification:
-    - This plan is stored in the CivicActions Guidebook GitHub repository (<https://github.com/CivicActions/guidebook/tree/master/common-practices-tools/security/>) with authorization to modify it limited to the Incident Response Team by GitHub access controls. CivicActions policy is that changes are proposed by making a pull request and ask another team member to review and merge the pull request.
+    - This plan is stored in the CivicActions Guidebook GitHub repository (<https://github.com/CivicActions/guidebook/tree/master/common-practices-tools/security/>) with authorization to modify it limited to SIRT members by GitHub access controls. CivicActions policy is that changes are proposed by making a pull request and ask another team member to review and merge the pull request.

--- a/common-practices-tools/security/incident-response-plan.md
+++ b/common-practices-tools/security/incident-response-plan.md
@@ -36,6 +36,7 @@ _Responders_ should acknowledge within 15 minutes.
 ### Responder
 
 A _Responder_ is generally a member of the CivicActions SIRT who investigates and remediates an event or incident.
+
 - Initially, the first _Responder_ is also the _Incident Commander_ (IC).
 - For the first 15-30 minutes, the first _Responder_ may work alone. If needed, they begin forming the _Incident Response Team_. See [Initiate](#3-initiate-the-response).
 
@@ -58,12 +59,12 @@ The _Incident Commander_ (IC) ideally remains uninvolved in remediation efforts,
     - Uses the most appropriate media/communication channels for recording actions. During business hours, _Incident Commander_ (IC) may create a dedicated Slack channel (for example, `#fire-team`) for SIRT communications.
     - Defines and enforces work shifts if the incident lasts longer than 3 hours.
 
-2. Documentation, including all actions taken during investigation and remediation, using the following methods:
+1. Documentation, including all actions taken during investigation and remediation, using the following methods:
 
     - Designated Slack or other communications channel
     - Project JIRA ticket or Gitlab issue (if applicable)
 
-3. Communication, ensuring that internal and external entities stay informed. For communication duties, the _Incident Commander_ (IC) may designate a _Communications Officer_ (CO) and do an [explicit handoff](#explicit-handoff-ceremony) for those duties.
+1. Communication, ensuring that internal and external entities stay informed. For communication duties, the _Incident Commander_ (IC) may designate a _Communications Officer_ (CO) and do an [explicit handoff](#explicit-handoff-ceremony) for those duties.
 
 ### Communications Officer
 
@@ -87,11 +88,11 @@ The _Incident Commander_ (IC) or the _Communications Officer_ (if one exists) de
 
 Severity determines response speed, disruption authority, and sitrep frequency. Assess quickly — it can change as the incident evolves.
 
-| Severity | Criteria (brief) | Response timing | Disruption authority | Sitrep frequency |
-|---|---|---|---|---|
-| **[High](#high-severity)** | SPII/CUI breach, large-scale availability impact, or significant financial harm | Immediate, continuous | SIRT acts without permission | Hourly or more |
-| **[Medium](#medium-severity)** | PII/FCI risk, targeted attacks, or limited service degradation | Business hours | Consult leads; act after 1 hr if unreachable | Twice daily |
-| **[Low](#low-severity)** | No customer impact; restricted to non-critical systems | Business hours | Mutually agreed with leads | Daily |
+| Severity                       | Criteria (brief)                                                                | Response timing       | Disruption authority                         | Sitrep frequency |
+| ------------------------------ | ------------------------------------------------------------------------------- | --------------------- | -------------------------------------------- | ---------------- |
+| **[High](#high-severity)**     | SPII/CUI breach, large-scale availability impact, or significant financial harm | Immediate, continuous | SIRT acts without permission                 | Hourly or more   |
+| **[Medium](#medium-severity)** | PII/FCI risk, targeted attacks, or limited service degradation                  | Business hours        | Consult leads; act after 1 hr if unreachable | Twice daily      |
+| **[Low](#low-severity)**       | No customer impact; restricted to non-critical systems                          | Business hours        | Mutually agreed with leads                   | Daily            |
 
 See [Incident severities](#incident-severities) for full criteria, examples, and contingency plan guidance.
 
@@ -126,7 +127,7 @@ An incident begins when someone becomes aware of a disruption in expected normal
 
 - Issue a broadcast notification via the designated [communication channel](#communication-channels).
 
-   - An example message follows. The format is not important, but the information fields are useful.
+    - An example message follows. The format is not important, but the information fields are useful.
 
 ```
 **Description**: [Short description of the event and its impact]
@@ -138,11 +139,14 @@ An incident begins when someone becomes aware of a disruption in expected normal
 **Details**: [Extra details about the event]
 ```
 
-  - Observe the following guidelines for communications:
+- Observe the following guidelines for communications:
+
     - During this stage of incident response, the event status is "investigating".
     - An unconfirmed issue is called an _event_. A confirmed issue is called an _incident_.
-  - For an incident requiring more than 30 minutes to resolve:
-     - Recruit additional _Responders_. Use `@security` to trigger a Slack notification for the Security team.
+
+- For an incident requiring more than 30 minutes to resolve:
+
+    - Recruit additional _Responders_. Use `@security` to trigger a Slack notification for the Security team.
     - Be sure to designate an [Incident Commander (IC)](#incident-commander) and [hand off the IC duties](#explicit-handoff-ceremony).
 
 - Use the [Explicit Handoff Ceremony](#explicit-handoff-ceremony) when transferring/changing roles.
@@ -283,22 +287,25 @@ The incident report should be posted in Slack, or in the ticket/issue as a final
 Severity dictates response speed, acceptable service disruption, and communication frequency. Severity can change over the lifespan of an incident, and the SIRT should assess the initial severity quickly.
 
 ### High severity
-*   **Criteria:** Compromises Sensitive Personally Identifiable Information (SPII), impacts availability for a large number of customers, or has a significant financial impact.
-*   **Examples:** Confirmed Sensitive Personally Identifiable Information (SPII) or Controlled Unclassified Information (CUI) breach, root-level production compromise, severe Denial of Service (DoS) outages, **developer system/supply-chain attacks** (e.g., the Shai-Hulud worm), and **AI agents breaking out of sandboxed environments**.
-*   **Response Guidelines:** Take action immediately to contain the issue, even if it requires complete service degradation. The CivicActions SIRT (or Project SIRT) does not need permission to act. Remediation is continuous. 
-*   **Communication:** Share sitreps hourly (or more frequently).
+
+- **Criteria:** Compromises Sensitive Personally Identifiable Information (SPII), impacts availability for a large number of customers, or has a significant financial impact.
+- **Examples:** Confirmed Sensitive Personally Identifiable Information (SPII) or Controlled Unclassified Information (CUI) breach, root-level production compromise, severe Denial of Service (DoS) outages, **developer system/supply-chain attacks** (e.g., the Shai-Hulud worm), and **AI agents breaking out of sandboxed environments**.
+- **Response Guidelines:** Take action immediately to contain the issue, even if it requires complete service degradation. The CivicActions SIRT (or Project SIRT) does not need permission to act. Remediation is continuous.
+- **Communication:** Share sitreps hourly (or more frequently).
 
 ### Medium severity
-*   **Criteria:** Poses a potential risk to "Rolodex" Personally Identifiable Information (PII) or Federal Contract Information (FCI), involves targeted attacks, or causes limited service degradation.
-*   **Examples:** Suspected PII breach, targeted but unsuccessful attempts to compromise production, spam/phishing targeting staff, or DoS attacks with limited degradation.
-*   **Response Guidelines:** Respond during SIRT business hours. Consult Project leads (via Slack or phone) to weigh disruption vs. security. Bias toward disruption—if leads cannot be reached within an hour, the SIRT may take action.
-*   **Communication:** Share sitreps twice daily.
+
+- **Criteria:** Poses a potential risk to "Rolodex" Personally Identifiable Information (PII) or Federal Contract Information (FCI), involves targeted attacks, or causes limited service degradation.
+- **Examples:** Suspected PII breach, targeted but unsuccessful attempts to compromise production, spam/phishing targeting staff, or DoS attacks with limited degradation.
+- **Response Guidelines:** Respond during SIRT business hours. Consult Project leads (via Slack or phone) to weigh disruption vs. security. Bias toward disruption—if leads cannot be reached within an hour, the SIRT may take action.
+- **Communication:** Share sitreps twice daily.
 
 ### Low severity
-*   **Criteria:** No noticeable customer impact, or restricted to non-critical systems. *(Note: General project-level incidents default to Low severity).*
-*   **Examples:** Attempted compromise of staging/testing instances, or DoS attacks with no noticeable impact.
-*   **Response Guidelines:** Respond during business hours. Consult SIRT members and notify Project leads. Do not take action or cause service degradation until a mutually-agreed course of action is determined.
-*   **Communication:** Share sitreps daily.
+
+- **Criteria:** No noticeable customer impact, or restricted to non-critical systems. *(Note: General project-level incidents default to Low severity).*
+- **Examples:** Attempted compromise of staging/testing instances, or DoS attacks with no noticeable impact.
+- **Response Guidelines:** Respond during business hours. Consult SIRT members and notify Project leads. Do not take action or cause service degradation until a mutually-agreed course of action is determined.
+- **Communication:** Share sitreps daily.
 
 ## Explicit Handoff Ceremony
 

--- a/common-practices-tools/security/incident-response-plan.md
+++ b/common-practices-tools/security/incident-response-plan.md
@@ -15,7 +15,7 @@ This document describes the process that the CivicActions Security Incident Resp
 
 > _During an incident, the [IRP checklist](incident-response-checklist.md) may be more useful as it contains bulleted, actionable items for the SIRT to follow._
 
-#### Security incidents may contain sensitive information
+### Security incidents may contain sensitive information
 
 - Don't discuss the breach in public channels before containment
 - Don't delete logs/evidence
@@ -129,7 +129,7 @@ An incident begins when someone becomes aware of a disruption in expected normal
 
     - An example message follows. The format is not important, but the information fields are useful.
 
-```
+```markdown
 **Description**: [Short description of the event and its impact]
 **Status**: investigating
 **Severity**: unknown
@@ -157,7 +157,7 @@ An incident begins when someone becomes aware of a disruption in expected normal
 
 ### 4. Assess the incident
 
-#### Confirm the incident.
+#### Confirm the incident
 
 - Gather information, and document your findings.
 
@@ -167,7 +167,7 @@ An incident begins when someone becomes aware of a disruption in expected normal
 
 - If a false alarm, proceed to [_6. Conclude the incident_](#6-conclude-the-incident).
 
-#### Assess the severity.
+#### Assess the severity
 
 - Does it affect system or data Confidentiality, Integrity, Availability and/or Privacy?
 - Use the [rubric for determining severity](#incident-severities). Project incidents are generally "LOW severity".
@@ -181,7 +181,7 @@ An incident begins when someone becomes aware of a disruption in expected normal
 - Post an initial situation report (_sitrep_), in the appropriate [communication channels](#communication-channels) as specified by the _Incident Commander_ (IC) (or _Communications Officer_ (CO)).
     - Here is an example _sitrep_:
 
-```
+```markdown
 **Subject**: [sitrep] Chickens are escaping
 **Severity**: LOW
 **Incident Commander**: Farmer Jane

--- a/common-practices-tools/security/incident-response-plan.md
+++ b/common-practices-tools/security/incident-response-plan.md
@@ -2,123 +2,98 @@
 title: Incident response plan
 ---
 
-# CivicActions Security Incident Response Procedures
+# CivicActions Security Incident Response Plan
 
-## Table of Contents
-
-<!--ts-->
-
-- [Introduction](#introduction)
-- [Roles and Responsibilities](#roles-and-responsibilities)
-    - [Responder](#responder)
-        - [First Responder](#first-responder)
-        - [IR Team Responders](#ir-team-responders)
-    - [Incident Commander](#incident-commander)
-    - [Communications Officer](#communications-officer)
-        - [Communication channels](#communication-channels)
-- [Incident response process](#incident-response-process)
-    - [1. <em>Breathe</em>](#1-breathe)
-    - [2. Start documenting](#2-start-documenting)
-    - [3. Initiate the response](#3-initiate-the-response)
-    - [4. Assess the incident](#4-assess-the-incident)
-        - [IR Team responsibilities during assessment](#ir-team-responsibilities-during-assessment)
-        - [Incident Commander responsibilities during assessment](#incident-commander-responsibilities-during-assessment)
-    - [5. Remediate](#5-remediate)
-        - [Remediation and service disruption](#remediation-and-service-disruption)
-        - [Remediation requiring more than 3 hours](#remediation-requiring-more-than-3-hours)
-        - [IR Team responsibilities during remediation](#ir-team-responsibilities-during-remediation)
-        - [Incident Commander responsibilities during remediation](#incident-commander-responsibilities-during-remediation)
-        - [Communications during remediation](#communications-during-remediation)
-    - [6. Conclude the incident](#6-conclude-the-incident)
-        - [Closing the ticket](#closing-the-ticket)
-        - [Conducting a retrospective](#conducting-a-retrospective)
-        - [Developing the incident report](#developing-the-incident-report)
-- [Incident severities](#incident-severities)
-    - [High severity](#high-severity)
-    - [Medium severity](#medium-severity)
-    - [Low severity](#low-severity)
-- [Explicit Handoff Ceremony](#explicit-handoff-ceremony)
-
-<!-- Added by: fen, at: Fri Jan 22 10:48:36 PM EST 2021 -->
-
-<!--te-->
-
----
+This Incident Response Plan (IRP) provides guidelines for managing an incident not covered by a client's incident response procedures and team. For most non-project-related incidents, see the [Security Incidents](incidents.md) page.
 
 ## Introduction
 
-This document describes the process that the CivicActions Incident Response Team follows when responding to security incidents and other disruptions that may affect the Confidentiality, Integrity, Availability (CIA) or Privacy of system resources and data. It explains:
+This document describes the process that the CivicActions Security Incident Response Team (SIRT) follows when responding to security incidents and other disruptions that may affect the Confidentiality, Integrity, Availability (CIA) or Privacy of system resources and data. It explains:
 
 - roles and responsibilities during and after incidents
 - overview of the steps to follow for resolution
 
-_During an incident, the [IRP checklist](incident-response-checklist.md) may be more useful as it contains bulleted, actionable items for the IR Team to follow. For most non-project-related incidents, see the [Security Incidents](incidents.md) page._
+> _During an incident, the [IRP checklist](incident-response-checklist.md) may be more useful as it contains bulleted, actionable items for the SIRT to follow._
+
+#### Security incidents may contain sensitive information
+
+- Don't discuss the breach in public channels before containment
+- Don't delete logs/evidence
+- Don't publicly disclose before stakeholders are notified.
 
 ## Roles and Responsibilities
 
 Individual and team roles are described below.
 
+### Reporter
+
+The person or non-human identity (NHI) that first observes what may be an incident and reports the issue to the SIRT. The primary responsibility of the _Reporter_ is to ensure that a _Responder_ acknowledges receipt of the report.
+
+Generally, raising the issue on the [#loving-security](https://civicactions.slack.com/messages/loving-security/) Slack channel will work. Use `@security` to trigger a Slack notification for the Security team.
+
+_Responders_ should acknowledge within 15 minutes.
+
 ### Responder
 
-A _Responder_ is a member of the CivicActions IR Team who investigates and remediates an event or incident.
+A _Responder_ is generally a member of the CivicActions SIRT who investigates and remediates an event or incident.
+- Initially, the first _Responder_ is also the _Incident Commander_ (IC).
+- For the first 15-30 minutes, the first _Responder_ may work alone. If needed, they begin forming the _Incident Response Team_. See [Initiate](#3-initiate-the-response).
 
-#### First Responder
-
-The _First Responder_ is the first IR Team member who becomes aware of the incident.
-
-- Frequently the _First Responder_ is also the _Incident Reporter_.
-- The _First Responder_ assumes the role as the _Incident Commander_ (IC) until [handing off IC duties](#explicit-handoff-ceremony).
-- For the first 15-30 minutes, the _First Responder_ may work alone. If needed, the _First Responder_ begins forming the IR Team. See [Initiate](#3-initiate-the-response).
-
-#### IR Team Responders
+#### Incident Response Team
 
 During incident response, _Responders_ do the following:
 
 - Assume primary responsibility for the [Assess](#4-assess-the-incident) and [Remediate](#5-remediate) steps.
-- Document in real time the measurements, theories, and steps taken using the Slack channel [#general](https://civicactions.slack.com/messages/general/) or other channels provided by the _Incident Commander_ (IC). Use `@security` to trigger a Slack notification for the Security team.
+- Document in real time the measurements, theories, and steps taken using a shared medium like Slack or a Google doc.
 - Designate an _Incident Commander_ (IC), if the incident might require more than 15-30 minutes to resolve, and do an [explicit handoff](#explicit-handoff-ceremony).
 
 ### Incident Commander
 
-The _Incident Commander_ (IC) remains uninvolved in remediation efforts, and performs three major duties:
+The _Incident Commander_ (IC) ideally remains uninvolved in remediation efforts, and performs three major duties:
 
-1. IR Team creation and management, ensuring that the IR Team:
+1. _Security Incident Response Team (SIRT)_ creation and management, ensuring that it:
 
     - Includes team members who are capable of containing, investigating, and remediating the incident.
     - Remains focused on resolving the incident.
-    - Uses the most appropriate media/communication channels for recording actions. During business hours, _Incident Commander_ (IC) may create a dedicated Slack channel (for example, #fire-team) for IR Team communications.
-    - Utilizes work shifts if the incident lasts longer than 3 hours.
+    - Uses the most appropriate media/communication channels for recording actions. During business hours, _Incident Commander_ (IC) may create a dedicated Slack channel (for example, `#fire-team`) for SIRT communications.
+    - Defines and enforces work shifts if the incident lasts longer than 3 hours.
 
-1. Documentation, including all actions taken during investigation and remediation, using the following methods:
+2. Documentation, including all actions taken during investigation and remediation, using the following methods:
 
-    - Slack channel [#general](https://civicactions.slack.com/messages/general/) (Use `@security` to trigger a Slack notification for the Security team.)
+    - Designated Slack or other communications channel
     - Project JIRA ticket or Gitlab issue (if applicable)
 
-1. Communication, ensuring that internal and external entities stay informed. For communication duties, the _Incident Commander_ (IC) may designate a _Communications Officer_ (CO) and do an [explicit handoff](#explicit-handoff-ceremony).
+3. Communication, ensuring that internal and external entities stay informed. For communication duties, the _Incident Commander_ (IC) may designate a _Communications Officer_ (CO) and do an [explicit handoff](#explicit-handoff-ceremony) for those duties.
 
 ### Communications Officer
-
-Communication is critical as the IR Team works to contain, investigate, and remediate an incident.
-
-The _Incident Commander_ (IC) manages communications regarding the incident until [handing off IC duties](#explicit-handoff-ceremony) to another IR Team member or designating a _Communications Officer_ (CO).
 
 The _Communications Officer_ (CO) manages external communications with:
 
 - Management, developers, users, and anyone affected by the incident
 - Client stakeholders (if applicable)
 - Additional Project team members and/or the Product Owner (if applicable)
-- CivicActions Legal team, and US-CERT if escalation is required
+- CivicActions Legal team, providing support if escalation is required to law enforcement or US-CERT
 
-#### Communication channels
+## Communication channels
 
-The _Incident Commander_ (IC) determines the most appropriate communication channels during incident response. Any of the following may be used:
+The _Incident Commander_ (IC) or the _Communications Officer_ (if one exists) determines the most appropriate communication channels during incident response. Any of the following may be used:
 
-- Slack channel [#general](https://civicactions.slack.com/messages/general/). Use `@security` to trigger a Slack notification for the Security team.
-- During business hours, _Incident Commander_ (IC) may create a dedicated Slack channel (for example, #fire-team) for IR Team communications.
+- Slack channel [`#loving-security`](https://civicactions.slack.com/messages/loving-security/) or a dedicated Slack channel (for example, `#fire-team`).
 - A JIRA ticket or Github/Gitlab issue for the incident (if applicable) will be the final location for all incident reporting, with links to other documents as needed.
-- Video conference: Zoom, Google Meet, Microsoft Teams, Skype, etc. (Be sure to record the call for documentation purposes.)
+- Video conference: Zoom, Slack Huddle, Google Meet, etc. (Be sure to record the call for documentation purposes.)
 - Email to [security@civicactions.com](mailto:security@civicactions.com).
-- Email/telephone to the [CivicActions IR Team](https://drive.google.com/open?id=1P9TePYm2Gkly8EjxCzA2EmlTjUIBypE7-CbCZrRN1EA) for an incident that has potential Project impact.
+
+## Severity at a glance
+
+Severity determines response speed, disruption authority, and sitrep frequency. Assess quickly — it can change as the incident evolves.
+
+| Severity | Criteria (brief) | Response timing | Disruption authority | Sitrep frequency |
+|---|---|---|---|---|
+| **[High](#high-severity)** | SPII/CUI breach, large-scale availability impact, or significant financial harm | Immediate, continuous | SIRT acts without permission | Hourly or more |
+| **[Medium](#medium-severity)** | PII/FCI risk, targeted attacks, or limited service degradation | Business hours | Consult leads; act after 1 hr if unreachable | Twice daily |
+| **[Low](#low-severity)** | No customer impact; restricted to non-critical systems | Business hours | Mutually agreed with leads | Daily |
+
+See [Incident severities](#incident-severities) for full criteria, examples, and contingency plan guidance.
 
 ## Incident response process
 
@@ -131,134 +106,92 @@ There are six major processes of incident response, detailed below:
 - [5. Remediate](#5-remediate)
 - [6. Conclude the incident](#6-conclude-the-incident)
 
-_During an incident, the [IRP checklist](incident-response-checklist.md) may be more useful as it contains bulleted, actionable items for the IR Team to follow._
-
 ### 1. _Breathe_
 
 No one's life is in danger.
 
 ### 2. Start documenting
 
-Begin documenting all steps and findings. Documentation makes handoffs and Responder onboarding easier. The Slack channel [#general](https://civicactions.slack.com/messages/general/) is recommended because it is most widely accessible, but other [communication channels](#communication-channels) may be used. When posting messages to Slack, use `@security` to trigger a Slack notification for the Security team.
+Begin documenting all steps and findings. Documentation makes handoffs and _Responder_ onboarding easier. A thread in the Slack channel [#loving-security](https://civicactions.slack.com/messages/loving-security/) is recommended because it is widely accessible, but other [communication channels](#communication-channels) may be used.
 
 ### 3. Initiate the response
 
-At this stage, the _First Responder_ is usually working alone, and is also the _Incident Commander_ (IC).
+At this stage, the first _Responder_ is usually working alone, and as such is also serving as the _Incident Commander_ (IC).
 
-A. Allocate 5 minutes and determine whether this event is a potential incident or false alarm. Consider any potential Project impact.
+Allocate 5 minutes and determine whether this event is a potential incident or false alarm. Consider any potential Project impact.
 
 An incident begins when someone becomes aware of a disruption in expected normal system operations. An incident is defined broadly, following [_NIST SP 800-61: Computer Security Incident Handling Guide_](https://csrc.nist.gov/publications/detail/sp/800-61/rev-2/final), as "a violation or imminent threat of violation of computer security policies, acceptable use policies, or standard security practices". This definition encompasses any scenario that might threaten the security of system resources and data. For more information, see the CivicActions guidebook: [What is an incident?](incidents.md#what-is-an-incident)
 
-B. Respond accordingly:
+#### Potential incident
 
-- Potential incident
+- Issue a broadcast notification via the designated [communication channel](#communication-channels).
 
-    1. Issue a broadcast notification via one or more of the following:
+   - An example message follows. The format is not important, but the information fields are useful.
 
-        - Slack channel [#general](https://civicactions.slack.com/messages/general/). Use `@security` to trigger a Slack notification for the Security team.
-        - Email to [security@civicactions.com](mailto:security@civicactions.com).
-        - Email/telephone to the [CivicActions IR Team](https://drive.google.com/open?id=1P9TePYm2Gkly8EjxCzA2EmlTjUIBypE7-CbCZrRN1EA) for an incident that has potential Project impact.
-        - An example message follows. The format is not important, but the information fields are useful.
+```
+**Description**: [Short description of the event and its impact]
+**Status**: investigating
+**Severity**: unknown
+**Incident Reporter**: [name of the person who reported the issue]
+**Incident Commander**: [your name]
+**Responders**: [names of other _Responders_]
+**Details**: [Extra details about the event]
+```
 
-        ```markdown
-            **Description**: [Short description of the event and its impact]
-            **Status**: investigating
-            **Severity**: unknown
-            **Incident Reporter**: [name of the person who reported the issue]
-            **Incident Commander**: [your name]
-            **Responders**: [names of other _Responders_]
-            **Details**: [Extra details about the event]
-        ```
+  - Observe the following guidelines for communications:
+    - During this stage of incident response, the event status is "investigating".
+    - An unconfirmed issue is called an _event_. A confirmed issue is called an _incident_.
+  - For an incident requiring more than 30 minutes to resolve:
+     - Recruit additional _Responders_. Use `@security` to trigger a Slack notification for the Security team.
+    - Be sure to designate an [Incident Commander (IC)](#incident-commander) and [hand off the IC duties](#explicit-handoff-ceremony).
 
-        - Observe the following guidelines for communications:
-            - During this stage of incident response, the event status is "investigating".
-            - An unconfirmed issue is called an _event_. A confirmed issue is called an _incident_.
+- Use the [Explicit Handoff Ceremony](#explicit-handoff-ceremony) when transferring/changing roles.
 
-    1. For an incident requiring more than 30 minutes to resolve:
+#### False alarm
 
-        - Recruit additional _Responders_ via the Slack channel [#general](https://civicactions.slack.com/messages/general/). Use `@security` to trigger a Slack notification for the Security team.
-        - Designate an [Incident Commander (IC)](#incident-commander) and [hand off the IC duties](#explicit-handoff-ceremony).
-
-    1. More information on [incident response roles and responsibilities](#roles-and-responsibilities):
-
-        - [Responder](#responder)
-        - [Incident Commander (IC)](#incident-commander)
-        - [Communications Officer (CO)](#communications-officer)
-
-    1. Use the [Explicit Handoff Ceremony](#explicit-handoff-ceremony) when transferring/changing roles.
-
-- False alarm
-
-Conclude the incident. Proceed to [_6. Conclude the incident_](#6-conclude-the-incident).
+- Proceed to [_6. Conclude the incident_](#6-conclude-the-incident).
 
 ### 4. Assess the incident
 
-#### IR Team responsibilities during assessment
+#### Confirm the incident.
 
-A. Confirm the incident.
+- Gather information, and document your findings.
 
-1. Gather information, and document your findings.
-
+    - Is there suspected evidence of malware or a malicious actor?
     - Was the event triggered by an [external dependency](contingency-plan.md#external-dependencies)?
     - Is a system failure causing the disruption?
 
-1. Proceed to the next step for a confirmed incident. (For a false alarm, conclude the incident. Proceed to [_6. Conclude the incident_](#6-conclude-the-incident).)
+- If a false alarm, proceed to [_6. Conclude the incident_](#6-conclude-the-incident).
 
-B. Assess the severity.
+#### Assess the severity.
 
-- Use the [rubric for determining severity](#incident-severities). Project incidents are generally "Low severity".
 - Does it affect system or data Confidentiality, Integrity, Availability and/or Privacy?
-- Note that severity can change over the lifespan of an incident, and it is acceptable for the IR Team to assess the initial severity quickly.
+- Use the [rubric for determining severity](#incident-severities). Project incidents are generally "LOW severity".
+- Note that severity can change over the lifespan of an incident, and it is acceptable for the SIRT to assess the initial severity quickly.
+- If HIGH severity or a projected need for Disaster Recovery, consider activation of the [Contingency Plan](contingency-plan.md).
 
-C. Determine whether the IR Team needs to activate the [Contingency Plan](contingency-plan.md). Consider whether Disaster Recovery is required.
+> The SIRT should record all actions and observations in an appropriate [communication channel](#communication-channels).
 
-The IR Team should record all actions and observations in an appropriate [communication channel](#communication-channels).
+#### Communication responsibilities during assessment
 
-_Reminder: Use the [Explicit Handoff Ceremony](#explicit-handoff-ceremony) when transferring/changing roles._
-
-#### Incident Commander responsibilities during assessment
-
-- Post an initial situation report (_sitrep_), in the following locations:
-
-    - Slack channel [#general](https://civicactions.slack.com/messages/general/) (Use `@security` to trigger a Slack notification for the Security team. Include link to the ticket/issue if applicable.)
-    - JIRA ticket or Gitlab issue (if applicable)
-    - Any other [communication channels](#communication-channels) as specified by the _Incident Commander_ (IC) (or _Communications Officer_ (CO)).
+- Post an initial situation report (_sitrep_), in the appropriate [communication channels](#communication-channels) as specified by the _Incident Commander_ (IC) (or _Communications Officer_ (CO)).
     - Here is an example _sitrep_:
 
-    ```markdown
-        **Subject**: \[sitrep\] Chickens are escaping
-        **Severity**: low
-        **Incident Commander**: Farmer Jane
-        **Responders**: Spot the Dog, Farmer Dave
-        **Description**: We've confirmed reports of escaped chickens. Looks like a fox may have tunneled into the run. Dave is working to fix the fence. Spot is tracking the fox.
-    ```
+```
+**Subject**: [sitrep] Chickens are escaping
+**Severity**: LOW
+**Incident Commander**: Farmer Jane
+**Responders**: Spot the Dog, Farmer Dave
+**Description**: We've confirmed reports of escaped chickens. Looks like a fox may have tunneled into the run. Dave is working to fix the fence. Spot is tracking the fox.
+```
 
-- For an issue with potential Project impact, ensure that a ticket/issue has been created. This should be done, even if the _First Responder/IC_ manages the incident fully, for example, by simply re-starting a service.
+- For an issue with potential Project impact, ensure that a ticket/issue has been created and the Project Manager informed.
 
 ### 5. Remediate
 
 Remediation is about resolving the issues caused by an incident. Remediation will be situation-specific, and timelines vary based on the assessed severity.
 
-#### Remediation and service disruption
-
-Remediation may require service disruption. If it does, the IR Team should proceed in a different way depending on the [severity](#incident-severities):
-
-- **High severity**: Take action immediately, even if this causes disruption. Send a notification about the disruption as soon as possible. The CivicActions IR Team, or Project IR Team if applicable, does not need permission to take action at this level.
-- **Medium severity**: Consult the other members of the CivicActions IR Team and agree on the best course of action. For an issue with Project impact, notify the Project leads about the planned action, and help them assess the relative risk of disruption versus security. If the leads are unavailable on Slack, contact them using the phone numbers in their Slack profiles. The Project team should reach a collaborative decision on action, with a bias towards disruption. If they cannot be reached within an hour, the Project IR Team may take action without them.
-- **Low severity**: Consult the other members of the CivicActions IR Team and agree on the best course of action. For an issue with Project impact, notify the Project leads as described above. Do not take action until a mutually-agreed course of action has been determined.
-
-#### Remediation requiring more than 3 hours
-
-Remediation takes time. If the issue progresses for more than 3 hours without being resolved, the _Incident Commander_ (IC) should plan for a long remediation. This means:
-
-- The _Incident Commander_ (IC) determines whether remediation efforts will occur during business hours only or be continuous. This depends on the severity of the issue, and whether breaches are ongoing.
-- For a continuous response, the _Incident Commander_ (IC) should plan shifts. This allows _Responders_ to take breaks and insures continuous coverage. Shifts should be no longer than 3 hours. Also, the _Incident Commander_ (IC) duties should rotate in shifts no longer than 3 hours.
-
-#### IR Team responsibilities during remediation
-
-- Determine the cause, implement a resolution, and return the system to normal operations. Make every attempt to identify the cause; this can prevent incident recurrence.
-- Maintain a list of informational leads from the incident — actionable information about any security breaches, stolen data, etc.
-- Develop a list of remediation steps. These can be tracked as checklists in Slack, shared Google Docs files, a JIRA ticket, Gitlab issue or another [communication channel](#communication-channels) as specified by the _Incident Commander_ (IC).
+#### Containment and evidence preservation
 
 If suspicious activity is suspected or other unanswered questions exist, do the following before making any changes:
 
@@ -267,38 +200,45 @@ If suspicious activity is suspected or other unanswered questions exist, do the 
 - Take screen captures of anomalous activity that can be used in post-remediation forensic analysis.
 - Consider implementing a containment strategy. For example, reconfigure firewall rules for the affected instance to drop all ingress and egress traffic, except from specific IPs like your own, until forensics can be performed.
 
+#### Remediation and service disruption
+
+Remediation may require service disruption. If it does, the SIRT should proceed in a different way depending on the assessed [severity](#incident-severities).
+
+#### SIRT responsibilities during remediation
+
+- Determine the cause, implement a resolution, and return the system to normal operations. Make every attempt to identify the cause; this can prevent incident recurrence.
+- Maintain a list of informational leads from the incident — actionable information about any security breaches, stolen data, etc.
+- Develop a list of remediation steps. These can be tracked as checklists in Slack, shared Google Docs files, a JIRA ticket, Gitlab issue or another [communication channel](#communication-channels).
+
+#### Long term planning
+
+Remediation takes time. If the issue progresses for more than 3 hours without being resolved, the _Incident Commander_ (IC) should plan for a long remediation. This means:
+
+- Determine whether remediation efforts will occur during business hours only or be continuous. This depends on the severity of the issue, and whether breaches are ongoing.
+- For a continuous response, plan shifts.
+
 #### Incident Commander responsibilities during remediation
 
 At a high level, the _Incident Commander_ (IC) tracks remediation actions, ensures they are assigned and followed, and verifies them when they are completed.
 
 The _Incident Commander_ (IC) must distinguish between immediate concerns, which need to be completed before the incident is considered resolved, and long-term improvements/hardening, which can be deferred to the Retrospective.
 
-The _Incident Commander_ (IC) does do the following:
+The _Incident Commander_ (IC) does the following:
 
-- Maintains current information in Slack, shared Google Docs files, a JIRA ticket, or another [communication channel](#communication-channels). Be sure to include:
-
-    - IR Team members and their roles, and/or Project team leads and members (if applicable)
+- Maintains current information in the designated [communication channel](#communication-channels). Be sure to include:
+    - SIRT members and their roles, and/or Project team leads and members (if applicable)
     - Remediation items and their assignees
-
 - Establishes and documents work shifts for an incident longer than 3 hours.
-
 - Maintains communications with stakeholders, or designates a _Communications Officer_ (CO) via [explicit handoff](#explicit-handoff-ceremony).
-
-- Shares _sitreps_ on a regular basis:
-
-    - High severity: hourly
-    - Medium severity: 2x daily
-    - Low severity: 1x daily
-
 - Focuses on coordination, communication, and information collection -- not remediation.
 
 #### Communications during remediation
 
-The _Incident Commander_ (IC) or _Communications Officer_ (CO) does this following:
+The _Incident Commander_ (IC) or _Communications Officer_ (CO):
 
 - Coordinates with the CivicActions managers to apprise them of the situation.
 - Coordinates with the Project Product Owner (PO), if applicable, to notify affected customers.
-- Ensures that the IR Team is recording all actions in the appropriate designated [communication channels](#communication-channels).
+- Ensures that the SIRT is recording all actions in the designated [communication channels](#communication-channels).
 - Shares _sitreps_ on a regular basis in Slack, in the ticket/issue (if applicable), and with stakeholders. See the section on [incident severities](#incident-severities) for suggested time intervals based on severity level.
 
 ### 6. Conclude the incident
@@ -309,9 +249,13 @@ When the incident is no longer active, for example, the breach has been containe
 
 To conclude an incident, the _Incident Commander_ (IC) should:
 
-- Set the status of the ticket/issue to **Ready for QA**.
+- Set the status of the ticket/issue to **Ready for Review**.
 - Send a final _sitrep_ to stakeholders, including CivicActions managers and the Security team.
 - Thank everyone involved for their service.
+
+#### Regulatory/user notification obligations
+
+- Consider external notification requirements (e.g., GDPR 72-hour rule, state breach notification laws) that may be triggered by certain incident types.
 
 #### Conducting a retrospective
 
@@ -323,11 +267,11 @@ The incident report should contain:
 
 - a timeline of the incident
 - details about how the incident progressed
-- information about the vulnerabilities that led to the incident, also called a _cause analysis_ (The _cause analysis_ is an important part of the incident report. Tools such as [Infinite Hows](https://www.kitchensoap.com/2014/11/14/the-infinite-hows-or-the-dangers-of-the-five-whys/) and [Five Whys](https://en.wikipedia.org/wiki/5_Whys) can help the IR Team explore potential causes, prevention, and improved incident response.)
+- information about the vulnerabilities that led to the incident, also called a _cause analysis_ (The _cause analysis_ is an important part of the incident report. Tools such as [Infinite Hows](https://www.kitchensoap.com/2014/11/14/the-infinite-hows-or-the-dangers-of-the-five-whys/) and [Five Whys](https://en.wikipedia.org/wiki/5_Whys) can help the SIRT explore potential causes, prevention, and improved incident response.)
 
 Additionally, the incident report should include basic response metrics:
 
-- **Discovery method**: How did the IR Team become aware of the issue?
+- **Discovery method**: How did the SIRT become aware of the issue?
 - **Time to discovery**: How much time passed from the time the incident became active until someone became aware of it?
 - **Time to containment**: How much time passed from the time someone became aware of the incident until the incident was contained?
 - **Threat actions**: What actions were taken by the actor? For example, phishing, password attacks, etc.
@@ -336,55 +280,25 @@ The incident report should be posted in Slack, or in the ticket/issue as a final
 
 ## Incident severities
 
-The incident severity level determines the actions of the IR Team. Severity usually changes during the lifecycle of the incident.
+Severity dictates response speed, acceptable service disruption, and communication frequency. Severity can change over the lifespan of an incident, and the SIRT should assess the initial severity quickly.
 
 ### High severity
-
-A high severity incident does one or more of the following:
-
-- compromises the confidentiality/integrity of Sensitive Personally Identifiable Information (SPII),
-- impacts the availability of services for a large number of customers, or
-- has significant financial impact.
-
-Examples include:
-
-- Confirmed breach of SPII
-- Successful root-level compromise of production systems
-- Denial of Service attacks resulting in severe outages
-
-Guidelines for incident response:
-
-- Remediation efforts will likely be continuous until the issue is contained.
-- _Responders_ may take any action required to contain the issue, including complete service degradation.
-- _Sitreps_ should be shared every hour, or more frequently.
+*   **Criteria:** Compromises Sensitive Personally Identifiable Information (SPII), impacts availability for a large number of customers, or has a significant financial impact.
+*   **Examples:** Confirmed Sensitive Personally Identifiable Information (SPII) or Controlled Unclassified Information (CUI) breach, root-level production compromise, severe Denial of Service (DoS) outages, **developer system/supply-chain attacks** (e.g., the Shai-Hulud worm), and **AI agents breaking out of sandboxed environments**.
+*   **Response Guidelines:** Take action immediately to contain the issue, even if it requires complete service degradation. The CivicActions SIRT (or Project SIRT) does not need permission to act. Remediation is continuous. 
+*   **Communication:** Share sitreps hourly (or more frequently).
 
 ### Medium severity
-
-A medium severity incident can be an unsuccessful attempt to breach Personally Identifiable Information (PII), an event with limited impact on the availability of services for a large number of users, or an event with limited financial impact. Examples include:
-
-- Suspected PII breach
-- Targeted but unsuccessful attempts to compromise production systems
-- Spam/phishing attacks targeting CivicActions or Project staff
-- Denial of Service attacks resulting in limited service degradation
-
-Guidelines for incident response:
-
-- Response should occur during business hours.
-- _Responders_ should attempt to consult stakeholders before causing downtime, but may proceed without consent if stakeholders do not respond in a reasonable time frame.
-- _Sitreps_ should be shared approximately twice per day.
+*   **Criteria:** Poses a potential risk to "Rolodex" Personally Identifiable Information (PII) or Federal Contract Information (FCI), involves targeted attacks, or causes limited service degradation.
+*   **Examples:** Suspected PII breach, targeted but unsuccessful attempts to compromise production, spam/phishing targeting staff, or DoS attacks with limited degradation.
+*   **Response Guidelines:** Respond during SIRT business hours. Consult Project leads (via Slack or phone) to weigh disruption vs. security. Bias toward disruption—if leads cannot be reached within an hour, the SIRT may take action.
+*   **Communication:** Share sitreps twice daily.
 
 ### Low severity
-
-A low severity incident does not affect PII, and has no availability or financial impact. Examples include:
-
-- Attempted compromise of non-important systems, for example, staging or testing instances
-- Denial of Service attacks with no noticeable customer impact
-
-Guidelines for incident response:
-
-- Response should occur during business hours.
-- _Responders_ should avoid service degradation unless stakeholders agree.
-- _Sitreps_ should be shared daily.
+*   **Criteria:** No noticeable customer impact, or restricted to non-critical systems. *(Note: General project-level incidents default to Low severity).*
+*   **Examples:** Attempted compromise of staging/testing instances, or DoS attacks with no noticeable impact.
+*   **Response Guidelines:** Respond during business hours. Consult SIRT members and notify Project leads. Do not take action or cause service degradation until a mutually-agreed course of action is determined.
+*   **Communication:** Share sitreps daily.
 
 ## Explicit Handoff Ceremony
 


### PR DESCRIPTION
## Describe your changes

### Overhaul incident response plan
https://civicactions-handbook--1772.org.readthedocs.build/en/1772/common-practices-tools/security/incident-response-plan/

- Rename document and standardize on SIRT terminology throughout
- Add Reporter role with 15-minute acknowledgment SLA
- Add "what not to do" guidance for sensitive incidents
- Elevate Communication channels to its own top-level section
- Restructure Step 5: containment/evidence preservation before disruption decision
- Add regulatory/user notification obligations to conclusion
- Move sitrep frequency out of IC checklist; point to severities section
- Replace manually-maintained HTML table of contents
- Fix ticket status (Ready for QA → Ready for Review)


### Flesh out contingency plan operational sections
 https://civicactions-handbook--1772.org.readthedocs.build/en/1772/common-practices-tools/security/contingency-plan/

- Activation: clarify IC role and tighten notification list
- Recovery: add root cause, backup/restore, dependency, and documentation steps
- Reconstitution: add verification checklist and explicit IC declaration/notification steps before retrospective

----
📚 Documentation preview 📚: https://civicactions-handbook--1772.org.readthedocs.build/en/1772/

<!-- readthedocs-preview civicactions-handbook end -->

<!-- readthedocs-preview civicactions-handbook start -->
----
📚 Documentation preview 📚: https://civicactions-handbook--1772.org.readthedocs.build/en/1772/

<!-- readthedocs-preview civicactions-handbook end -->

<!-- readthedocs-preview civicactions-handbook start -->
----
📚 Documentation preview 📚: https://civicactions-handbook--1772.org.readthedocs.build/en/1772/

<!-- readthedocs-preview civicactions-handbook end -->