### PR TITLE
update with incident reporting via #it-support

### DIFF
--- a/common-practices-tools/security/incident-response-plan.md
+++ b/common-practices-tools/security/incident-response-plan.md
@@ -4,14 +4,15 @@ title: Incident response plan
 
 # CivicActions Security Incident Response Plan
 
-This Incident Response Plan (IRP) provides guidelines for managing an incident not covered by a client's incident response procedures and team. For most non-project-related incidents, see the [Security Incidents](incidents.md) page.
+_For how to report a non-project-related incident, see the [Security Incidents](incidents.md) page._
 
 ## Introduction
 
-This document describes the process that the CivicActions Security Incident Response Team (SIRT) follows when responding to security incidents and other disruptions that may affect the Confidentiality, Integrity, Availability (CIA) or Privacy of system resources and data. It explains:
+This Incident Response Plan (IRP) describes how the CivicActions Security Incident Response Team (SIRT) responds to security incidents and other disruptions - particularly those not covered by a client's own incident response procedures - that may affect the Confidentiality, Integrity, Availability (CIA), or Privacy of system resources and data. It explains:
 
-- roles and responsibilities during and after incidents
+- roles and responsibilities during and after incidents including handoff procedures
 - overview of the steps to follow for resolution
+- how to conduct a retrospective
 
 > _During an incident, the [IRP checklist](incident-response-checklist.md) may be more useful as it contains bulleted, actionable items for the SIRT to follow._
 

--- a/common-practices-tools/security/incident-response-plan.md
+++ b/common-practices-tools/security/incident-response-plan.md
@@ -31,6 +31,8 @@ The person or non-human identity (NHI) that first observes what may be an incide
 
 Generally, raising the issue on the [#loving-security](https://civicactions.slack.com/messages/loving-security/) Slack channel will work. Use `@security` to trigger a Slack notification for the Security team.
 
+A critical issue can be raised on the [`#it-support`](https://civicactions.slack.com/messages/it-support/) channel by including the word “Incident”.
+
 _Responders_ should acknowledge within 15 minutes.
 
 ### Responder

--- a/common-practices-tools/security/incident-response-plan.md
+++ b/common-practices-tools/security/incident-response-plan.md
@@ -31,7 +31,7 @@ The person or non-human identity (NHI) that first observes what may be an incide
 
 Generally, raising the issue on the [#loving-security](https://civicactions.slack.com/messages/loving-security/) Slack channel will work. Use `@security` to trigger a Slack notification for the Security team.
 
-A critical issue can be raised on the [`#it-support`](https://civicactions.slack.com/messages/it-support/) channel by including the word “Incident”.
+A critical issue can be raised on the [`#it-support`](https://civicactions.slack.com/messages/it-support/) channel by including the word "Incident".
 
 _Responders_ should acknowledge within 15 minutes.
 

--- a/common-practices-tools/security/incidents.md
+++ b/common-practices-tools/security/incidents.md
@@ -53,7 +53,7 @@ _Else, if unsure this is a critical issue:_
     - What systems or data may be affected
     - What actions you've already taken (if any)
 
-     You can mention the `@security` group to explicitly notify its members.
+    You can mention the `@security` group to explicitly notify its members.
 
 _If a critical issue or no help after 15 minutes:_
 

--- a/common-practices-tools/security/incidents.md
+++ b/common-practices-tools/security/incidents.md
@@ -57,7 +57,7 @@ _Else, if unsure this is a critical issue:_
 
 _If a critical issue or no help after 15 minutes:_
 
-4. Repost the above on [`#it-support`](https://civicactions.slack.com/messages/it-support/) and include the word “Incident” which will alert the Security Incident Response Team (SIRT).
+4. Repost the above on [`#it-support`](https://civicactions.slack.com/messages/it-support/) and include the word "Incident" which will alert the Security Incident Response Team (SIRT).
 
 _After reporting, follow the Responder's lead:_
 

--- a/common-practices-tools/security/incidents.md
+++ b/common-practices-tools/security/incidents.md
@@ -36,19 +36,32 @@ Time is critical - the SIRT will initiate the [Incident Response Plan](incident-
 
 ### How to report
 
-1. **Post in [`#loving-security`](https://civicactions.slack.com/messages/loving-security/)** using `@security` to notify the SIRT. Include:
+_Project-specific incident?_
 
+1. Follow project reporting guidelines and/or post in your project Slack channel or elsewhere.
+
+_Else, check if already reported:_
+
+2. Look at recent posts in [`#it-support`](https://civicactions.slack.com/messages/it-support/). If already reported and you have additional information, add it.
+
+_Else, if unsure this is a critical issue:_
+
+3. Post on [`#loving-security`](https://civicactions.slack.com/messages/loving-security/) first to obtain community-supported help. Include:
+
+    - What you did (e.g. clicked on a phishing link)
     - What you observed and when
     - What systems or data may be affected
     - What actions you've already taken (if any)
 
-1. **Wait for acknowledgment** - a Responder should reply within 15 minutes. If the issue seems serious, stay available until someone confirms they've picked it up.
+     You can mention the `@security` group to explicitly notify its members.
 
-1. **No response after 15 minutes?** Email [security@civicactions.com](mailto:security@civicactions.com) with _Security Incident_ in the subject line.
+_If a critical issue or no help after 15 minutes:_
 
-1. **Project-specific incident?** Also post in your project Slack channel with `@security` so your Project Manager is looped in.
+4. Repost the above on [`#it-support`](https://civicactions.slack.com/messages/it-support/) and include the word “Incident” which will alert the Security Incident Response Team (SIRT).
 
-After reporting, **follow the Responder's lead** - they may ask you to preserve evidence, provide more detail, or to stand by.
+_After reporting, follow the Responder's lead:_
+
+5. They may ask you to preserve evidence, provide more detail, or to stand by.
 
 ## Some common incident types
 


### PR DESCRIPTION
Add incident reporting via #it-support (with "Incident" keyword triggering SIRT alert) as an alternative escalation path. Updates the reporting flow in incidents.md to a numbered, conditional checklist, and adds a note to incident-response-plan.md about using #it-support for critical issues.

<!-- readthedocs-preview civicactions-handbook start -->
----
📚 Documentation preview 📚: https://civicactions-handbook--1790.org.readthedocs.build/en/1790/

<!-- readthedocs-preview civicactions-handbook end -->